### PR TITLE
Add Doxygen comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@ All code modifications must follow modern formatting conventions and include tho
 Future contributors should decompose, unroll, flatten, factor, and modernize any legacy constructs encountered.
 All touched files must be rewritten in the most modern idiomatic style possible, informed by mathematical reasoning and explicit decomposition, unrolling, flattening, factoring, and synthesis of obsolete patterns.
 Every modified file must also be reviewed in the context of the entire architecture.  Functions should be decomposed and refactored for SIMD-friendly algorithms (MMX, SSE1‑4.2, SSSE3, SSE4a, FMA1‑4, AVX1/2/512/512VNNI, and later).  Apply modern formatting only to the code itself—not comments—and ensure all code is documented using Doxygen.
+\nContributors must further ensure all decompositions and refactorings follow mathematically proven correctness and use modern idiomatic patterns.

--- a/usr.bin/apply/apply.c
+++ b/usr.bin/apply/apply.c
@@ -52,9 +52,26 @@ __RCSID("$NetBSD: apply.c,v 1.19 2016/03/12 22:28:04 dholland Exp $");
 #include <string.h>
 #include <unistd.h>
 
+/** Display usage information and exit. */
 static __dead void usage(void);
-static int shell_system(const char *);
 
+/** Execute a command using the user's shell.
+ *
+ * @param command Command string to run.
+ * @return The exit status of the command or -1 on error.
+ */
+static int shell_system(const char *command);
+
+/**
+ * Program entry point.
+ *
+ * Parses command-line options and invokes the specified command on
+ * successive argument groups.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return 0 on success, non-zero on failure.
+ */
 int
 main(int argc, char *argv[])
 {
@@ -197,10 +214,14 @@ main(int argc, char *argv[])
 	return rval;
 }
 
-/*
- * shell_system --
- * 	Private version of system(3).  Use the user's SHELL environment
- *	variable as the shell to execute.
+/**
+ * Execute a command using the user's shell.
+ *
+ * Replacement for system(3) that respects the SHELL environment
+ * variable.
+ *
+ * @param command Command string to execute.
+ * @return The exit status of the command or -1 on failure.
  */
 static int
 shell_system(const char *command)
@@ -251,6 +272,7 @@ shell_system(const char *command)
 	/*NOTREACHED*/
 }
 
+/** Print usage information and terminate. */
 static __dead void
 usage(void)
 {


### PR DESCRIPTION
## Summary
- expand AGENTS guidelines with note on mathematically-proven refactorings
- document apply utility with Doxygen comments

## Testing
- `./setup.sh`
- `./tests/unit/test_fsm_rules`
- `make check` in `tests/vm` *(fails: unknown type names in headers)*
- `doxygen docs/Doxyfile` *(produces warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68464f76a0048331b8d35ed34325083a